### PR TITLE
New name proposal for Stepper

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please add your ideas and suggesitons, pull request is super-easy and fast on Gi
 | StackLayout       | StackPanel                 | StackPanel                                  |
 | ScrollView        | ScrollViewer               | ScrollViewer                                |
 | Switch            | ToggleSwitch               | ToggleSwitch                                |
-| Stepper           | NumericUpDown              | NumericStepper, NumericUpDown, NumericInput |
+| Stepper           | NumberBox                  | NumberBox, NumericUpDown                    |
 | Frame             | Border                     | Border                                      |
 | Slider            | Slider                     | Slider                                      |
 | ActivityIndicator | ProgressRing               | ProgressRing                                |
@@ -46,12 +46,10 @@ Please add your ideas and suggesitons, pull request is super-easy and fast on Gi
 
 ## Object Model
 
-Community Suggestions. Visit the origin to see full discussions around the idea.
-
+Community Suggestions
 | Suggestion | Origin |
 | ---------- | ----------------------- |
 | Base Architecture (fork from): UWP | [Pull Request #4](https://github.com/LanceMcCarthy/MauiSuggestions/pull/4) |
-| XAML-defined animations (without attaching behaviors) | [Issue #1](https://github.com/LanceMcCarthy/MauiSuggestions/issues/1) |
 
 
 


### PR DESCRIPTION
In the column other XAML it was written the name NumericUpDown, but WPF has never had such a control. There was a NUD in the Silverlight toolkit as well as in Windows Forms, but the former is obsolete and the later is not a XAML framework. On the other hand, recently the WinUI team has released a NumberBox control with a very similar API than the NumericUpDown. So I think, NumberBox would be name the align the most. Optionally, I wrote the name NumericUpDown since that is the classical one, so to speak.